### PR TITLE
gstreamer improvements

### DIFF
--- a/image/device.go
+++ b/image/device.go
@@ -2,6 +2,7 @@ package image
 
 // DeviceCap describes a capability of a device.
 type DeviceCap struct {
+	Type      string // "video/x-raw", "image/jpeg" or "nvarguscamerasrc"
 	Width     int
 	Height    int
 	Framerate int


### PR DESCRIPTION
- Only use device capability >= 640x480, and just use 640x480 if there is no match.
- Allow image/jpeg streams.
- Deal with Jetson Nano CSI.

Note: I haven't been able to test with an image/jpeg stream, or with an nvarguscamerasrc camera. Could you try that? For nvarguscamerasrc, I could write a test for parsing the output for ListDevices if you have an example output.